### PR TITLE
split ci into stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,19 @@ install:
   - pip install pre-commit
 stages:
   - name: validate
+  - name: test
+  - name: package
 jobs:
   include:
     - stage: validate
       script:
         - pre-commit autoupdate
         - pre-commit run --all-files
+    - stage: test
+      script:
         - make install
-        - make build
         - make test
+    - stage: package
+      script:
+        - make install
+        - make package

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 python: 3.7
 cache: pip
 fast_finish: true
+addons:
+  apt_packages:
+    - pandoc
 env:
   global:
     - buildnum=$TRAVIS_BUILD_NUMBER

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,9 @@ language: python
 python: 3.7
 cache: pip
 fast_finish: true
-addons:
-  apt_packages:
-    - pandoc
 env:
   global:
     - buildnum=$TRAVIS_BUILD_NUMBER
-install:
-  - pip install pre-commit
 stages:
   - name: validate
   - name: test
@@ -19,6 +14,7 @@ jobs:
   include:
     - stage: validate
       script:
+        - make install
         - pre-commit autoupdate
         - pre-commit run --all-files
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 sudo: false
 language: python
-python: 3.6
+python: 3.7
 cache: pip
 fast_finish: true
+addons:
+  apt_packages:
+    - pandoc
 env:
   global:
     - buildnum=$TRAVIS_BUILD_NUMBER

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ jcapiv1@git+https://github.com/TheJumpCloud/jcapi-python.git@v3.3.0#subdirectory
 jcapiv2@git+https://github.com/TheJumpCloud/jcapi-python.git@v3.3.0#subdirectory=jcapiv2
 
 mock>=2.0.0,<2.1.0
-pandoc>=1.0.0
 pip-check-reqs>=2.0.1,<3
 pip-licenses>=1.7.1,<2
 pre-commit>=2.4.0,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ jcapiv1@git+https://github.com/TheJumpCloud/jcapi-python.git@v3.3.0#subdirectory
 jcapiv2@git+https://github.com/TheJumpCloud/jcapi-python.git@v3.3.0#subdirectory=jcapiv2
 
 mock>=2.0.0,<2.1.0
+pandoc>=1.0.0
 pip-check-reqs>=2.0.1,<3
 pip-licenses>=1.7.1,<2
 pre-commit>=2.4.0,<3


### PR DESCRIPTION
* Split the travis build into stages: validate, test, and package.
* Use pandoc to convert markdown to rst