### PR TITLE
Issue #27: Option-based Input

### DIFF
--- a/jccli/cli.py
+++ b/jccli/cli.py
@@ -69,21 +69,6 @@ def create_user(ctx, username, email, first_name, last_name, allow_public_key, l
     response = api1.create_user(systemuser)
     LOGGER.info(f"{response}")
 
-# @cli.command()
-# @click.option('--username', "-u", required=True, type=str, help='The user name')
-# @click.pass_context
-# def delete_user(ctx, username):
-#     """
-#     Delete a jumpcloud user
-#     """
-#     api1 = JumpcloudApiV1(ctx.obj.get('key'))
-#     user_id = api1.get_user_id(username)
-#     if user_id is None:
-#         raise SystemUserNotFoundError(f"System user {username} not found")
-#
-#     response = api1.delete_user(user_id)
-#     LOGGER.info(f"{response}")
-
 @cli.command()
 @click.option('--username', "-u", required=True, type=str, help='The user name')
 @click.pass_context

--- a/jccli/cli.py
+++ b/jccli/cli.py
@@ -45,28 +45,22 @@ def cli(ctx, key):
 @click.option('--email', '-e', required=True, type=str)
 @click.option('--first-name', '-f', type=str, default='')
 @click.option('--last-name', '-l', type=str, default='')
-@click.option('--account-locked', is_flag=True)
-@click.option('--activated', is_flag=True)
 @click.option('--allow-public-key/--disallow-public-key', default=True)
 @click.option('--ldap-binding-user', is_flag=True)
 @click.option('--passwordless-sudo', is_flag=True)
 @click.option('--sudo', is_flag=True)
 @click.pass_context
-def create_user(ctx, username, email, first_name, last_name, account_locked, activated, allow_public_key,
-                ldap_binding_user, passwordless_sudo, sudo):
+def create_user(ctx, username, email, first_name, last_name, allow_public_key, ldap_binding_user, passwordless_sudo,
+                sudo):
     """
     Create a new Jumpcloud user
     """
-    # TODO: Test whether the flags are working. So far, --disallow-public-key does work, but --activated doesn't seem to
-    #  be doing anything!
     api1 = JumpcloudApiV1(ctx.obj.get('key'))
     systemuser = {
         'username': username,
         'email': email,
         'first_name': first_name,
         'last_name': last_name,
-        'account_locked': str(account_locked),
-        'activated': str(activated),
         'allow_public_key': str(allow_public_key),
         'ldap_binding_user': str(ldap_binding_user),
         'passwordless_sudo': str(passwordless_sudo),

--- a/jccli/cli.py
+++ b/jccli/cli.py
@@ -41,25 +41,38 @@ def cli(ctx, key):
     }
 
 @cli.command()
-@click.option('--json', "-j", required=False, type=str,
-              help='SystemUser properties json')
-@click.option('--file', "-f", required=False, type=click.Path(exists=True),
-              help='SystemUser properties file')
+@click.option('--username', '-u', required=True, type=str)
+@click.option('--email', '-e', required=True, type=str)
+@click.option('--first-name', '-f', type=str, default='')
+@click.option('--last-name', '-l', type=str, default='')
+@click.option('--account-locked', is_flag=True)
+@click.option('--activated', is_flag=True)
+@click.option('--allow-public-key/--disallow-public-key', default=True)
+@click.option('--ldap-binding-user', is_flag=True)
+@click.option('--passwordless-sudo', is_flag=True)
+@click.option('--sudo', is_flag=True)
 @click.pass_context
-def create_user(ctx, json, file):
+def create_user(ctx, username, email, first_name, last_name, account_locked, activated, allow_public_key,
+                ldap_binding_user, passwordless_sudo, sudo):
     """
     Create a new Jumpcloud user
     """
+    # TODO: Test whether the flags are working. So far, --disallow-public-key does work, but --activated doesn't seem to
+    #  be doing anything!
     api1 = JumpcloudApiV1(ctx.obj.get('key'))
-    user = {}
-    if json is not None:
-        user = jccli_helpers.get_user_from_term(json)
-    elif file is not None:
-        user = jccli_helpers.get_user_from_file(file)
-    else:
-        raise MissingRequiredArgumentError("SystemUser properties not provided")
-
-    response = api1.create_user(user)
+    systemuser = {
+        'username': username,
+        'email': email,
+        'first_name': first_name,
+        'last_name': last_name,
+        'account_locked': str(account_locked),
+        'activated': str(activated),
+        'allow_public_key': str(allow_public_key),
+        'ldap_binding_user': str(ldap_binding_user),
+        'passwordless_sudo': str(passwordless_sudo),
+        'sudo': str(sudo)
+    }
+    response = api1.create_user(systemuser)
     LOGGER.info(f"{response}")
 
 # @cli.command()

--- a/jccli/jc_api_v1.py
+++ b/jccli/jc_api_v1.py
@@ -66,10 +66,6 @@ class JumpcloudApiV1:
                                          email=systemuser['email'],
                                          firstname=systemuser.get('firstname', ''),
                                          lastname=systemuser.get('lastname', ''),
-                                         account_locked=strtobool(
-                                             systemuser.get('account_locked', 'False')),
-                                         activated=strtobool(
-                                             systemuser.get('activated', 'False')),
                                          allow_public_key=strtobool(
                                              systemuser.get('allow_public_key', 'True')),
                                          ldap_binding_user=strtobool(

--- a/jccli/jc_api_v1.py
+++ b/jccli/jc_api_v1.py
@@ -84,7 +84,8 @@ class JumpcloudApiV1:
                                                                   x_org_id='')
             return api_response
         except ApiException as error:
-            raise "Exception when calling SystemusersApi->systemusers_post: %s\n" % error
+            # FIXME: What should this behavior actually be?
+            raise Exception("Exception when calling SystemusersApi->systemusers_post: %s\n" % error)
 
     def delete_user(self, username):
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,15 +81,9 @@ class TestCli:
             result.output.strip() == "Group foo deleted",
         ), "Invalid response in output."
 
-    def test_create_user_no_arguments(self):
-        runner: CliRunner = CliRunner()
-        with pytest.raises(jccli_errors.MissingRequiredArgumentError):
-            runner.invoke(cli.cli, ["create-user"], catch_exceptions=False)
 
-    @patch.object(jccli_helpers,'get_user_from_term')
     @patch.object(JumpcloudApiV1,'create_user')
-    def test_create_user_json(self, mock_create_user, mock_get_user_from_term):
-        mock_get_user_from_term.return_value = "jctester1"
+    def test_create_user(self, mock_create_user):
         response = {
          "account_locked": "False",
          "email": "jc.tester1@sagebase.org",
@@ -98,71 +92,23 @@ class TestCli:
          "username": "jctester1"}
         mock_create_user.return_value = response
 
-        payload = {
-         "email": "jc.tester1@sagebase.org",
-         "username": "jctester1"}
-
-
         runner: CliRunner = CliRunner()
+        # FIXME: This doesn't test much that is meaningful; it's going to get the same mock answer regardless of the
+        #  arguments sent to the CLI invoker. I.e.: all it tests is whether the below command successfully makes a call
+        #  to JumpcloudApiV1.create_user, *not* whether it is the right call or even a well-formed one.
         result: Result = runner.invoke(cli.cli,
-                                       ["create-user",
-                                        "--json",
-                                        json.dumps(payload)])
-        res_out = result.output.split('\n')[1].replace("\'", "\"")
-        assert (
-            res_out == json.dumps(response)
-        ), "Invalid response in output."
-
-    @patch.object(jccli_helpers,'get_user_from_term')
-    @patch.object(JumpcloudApiV1,'create_user')
-    def test_create_user_json(self, mock_create_user, mock_get_user_from_term):
-        mock_get_user_from_term.return_value = "jctester1"
-        response = {
-         "account_locked": "False",
-         "email": "jc.tester1@sagebase.org",
-         "id": "5dc0d38c1e2e5f51f2312948",
-         "organization": "5a9d7329feb7f81004ecbee4",
-         "username": "jctester1"}
-        mock_create_user.return_value = response
-
-        payload = {
-         "email": "jc.tester1@sagebase.org",
-         "username": "jctester1"}
-
-
-        runner: CliRunner = CliRunner()
-        result: Result = runner.invoke(cli.cli,
-                                       ["create-user",
-                                        "--json",
-                                        json.dumps(payload)])
+            [
+                "create-user",
+                "--email",
+                "jc.tester1@sagebase.org",
+                "--username",
+                "jctester1"
+            ]
+        )
         res_out = result.output.split('\n')[0].replace("\'", "\"")
         assert (
             res_out == json.dumps(response)
         ), "Invalid response in output."
-
-
-    @patch.object(jccli_helpers,'get_user_from_file')
-    @patch.object(JumpcloudApiV1,'create_user')
-    def test_create_user_file(self, mock_create_user, mock_get_user_from_file):
-        mock_get_user_from_file.return_value = "jctester"
-        response = {
-         "account_locked": "False",
-         "email": "jc.tester@sagebase.org",
-         "id": "5dc0d38c1e2e5f51f2312948",
-         "organization": "5a9d7329feb7f81004ecbee4",
-         "username": "jctester"}
-        mock_create_user.return_value = response
-
-        runner: CliRunner = CliRunner()
-        result: Result = runner.invoke(cli.cli,
-                                       ["create-user",
-                                        "--file",
-                                        "tests/jc_test_user.json"])
-        res_out = result.output.split('\n')[0].replace("\'", "\"")
-        assert (
-            res_out == json.dumps(response)
-        ), "Invalid response in output."
-
 
     @patch.object(JumpcloudApiV1,'delete_user')
     @patch.object(JumpcloudApiV1,'get_user_id')


### PR DESCRIPTION
Switch the create-user command to option-based input.

There are a few things I want to note: there are unit tests for the CLI, but they do not test much of significance. Basically, all they do is check whether the command results in a call to a mock API object--and *not* anything about the specific contents of that call. I'm working on a change to that as part of Issue #24 . I did enough testing by hand to think that this command is working reasonably well.

I removed some flags (--activated, --account-locked) from an earlier version that appear to have no effect, and indeed are not present on JC's spec of their PowerConsole version of this command: https://github.com/TheJumpCloud/support/wiki/New-JCUser .