### PR TITLE
Fix travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
-sudo: false
 language: python
 python: 3.7
 cache: pip
-fast_finish: true
 addons:
   apt_packages:
     - pandoc
@@ -16,6 +14,7 @@ stages:
   - name: package
   - name: publish
 jobs:
+  fast_finish: true
   include:
     - stage: validate
       script:


### PR DESCRIPTION
Fix these issues:
```
➜  travis lint .travis.yml
Warnings for .travis.yml:
[x] [warn] on root: unknown key fast_finish (true)
[x] [warn] on root: deprecated key: sudo (The key `sudo` has no effect anymore.)
```
fast_finish was in the wrong location and sudo has been deprecated