### PR TITLE
Fix publish to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ jobs:
         - make install
         - make publish
         - bumpversion patch --config-file setup.cfg
-        - git add -u && git commit -m "[ci skip] bump version" && git push
+        - git add -u && git commit -m "[ci skip] bump version" && git push origin HEAD:master

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ answers:
 
 # -q flag is a workaround for jcapi-python lib not being in pypi (issue #9)
 package: clean docs
-	python setup.py -q sdist bdist_wheel
+        # pypi doesn't support bdist_wheel due to direct dependency on github
+	python setup.py -q sdist
 	twine check dist/*
 	ls -l dist
 


### PR DESCRIPTION
* pypi doesn't support direct github dependencies with wheel
packages so we remove bdist_wheel from build

* fix command to push bump versionm to repo.