### PR TITLE
manually bump version

### DIFF
--- a/jccli/version.py
+++ b/jccli/version.py
@@ -8,5 +8,5 @@
 This module contains project version information.
 """
 
-__version__ = "0.0.9"  #: the working version
-__release__ = "0.0.9"  #: the release version
+__version__ = "0.0.10"  #: the working version
+__release__ = "0.0.10"  #: the release version

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.9
+current_version = 0.0.10
 
 [bumpversion:file:./jccli/version.py]
 search = version: {current_version}


### PR DESCRIPTION
The v0.0.9 release partially failed, travis published v0.0.9 to pypi
but failed to bump the version therefore we need to manually
bump the version so travis won't try to publish the same version
to pypi again on the next release. This sets travis ci up to do
the next publish and version bumnp.