### PR TITLE
[Fixes #76] Do Not Require Key for all Command Groups

### DIFF
--- a/jccli/cli/__init__.py
+++ b/jccli/cli/__init__.py
@@ -40,12 +40,8 @@ def cli(ctx, key, profile):
         sys.exit("no profile found named: %s" % (profile,))
 
     # Try to get key from CLI, then from config
-    if key:
-        key = key
-    elif 'key' in config:
+    if not key and 'key' in config:
         key = config['key']
-    else:
-        sys.exit("please provide API key in config file, as optional argument, or as environmental variable")
 
     ctx.obj = {
         'key': key,


### PR DESCRIPTION
This will allow users to get help from command groups without providing an API key