### PR TITLE
[Fixes #67] Handle Pagination

### DIFF
--- a/jccli/cli/sync.py
+++ b/jccli/cli/sync.py
@@ -130,7 +130,7 @@ def sync_users(ctx, users):
     jc_usernames = []
     jc_emails = []
     jc_users = []
-    jc_users_request = api1.get_users()
+    jc_users_request = api1.search_users()
     if jc_users_request:
         for jc_user in jc_users_request:
             jc_usernames.append(jc_user['username'])

--- a/jccli/helpers.py
+++ b/jccli/helpers.py
@@ -12,6 +12,10 @@ import json
 import yaml
 
 
+# Total number of results to allow in one API request
+PAGE_LIMIT = 100
+
+
 def class_to_dict(class_object):
     """
     Convert a list of jumpcloud users to a list of dicts

--- a/jccli/jc_api_v1.py
+++ b/jccli/jc_api_v1.py
@@ -17,7 +17,7 @@ import jcapiv1
 from jcapiv1 import Systemuserput, Systemput
 from jcapiv1.rest import ApiException
 from jccli.errors import SystemUserNotFoundError, JcApiException
-from jccli.helpers import class_to_dict, make_query_filter
+from jccli.helpers import class_to_dict, make_query_filter, PAGINATION_LIMIT
 
 
 # pylint: disable=too-many-arguments
@@ -37,7 +37,7 @@ class JumpcloudApiV1:
         Retrieve a list of users corresponding to ids
         """
         # FIXME: This is not an ideal way to do this, but search_systemusers_post doesn't seem to allow filtering on ID
-        all_users = self.get_users()
+        all_users = self.search_users()
         return [user for user in all_users if user['id'] in user_ids]
 
     def search_users(self, filter={}):
@@ -52,43 +52,23 @@ class JumpcloudApiV1:
         query_filter = make_query_filter(filter)
 
         try:
-            api_response = self.search_api.search_systemusers_post(
-                content_type='application/json',
-                accept='application/json',
-                body={
-                    'filter': query_filter
-                }
-            )
-            users = [user.to_dict() for user in api_response.results]
-            return users
+            # Cycle through "limited" (paginated) API responses
+            users = []
+            while True:
+                api_response = self.search_api.search_systemusers_post(
+                    content_type='application/json',
+                    accept='application/json',
+                    body={
+                        'filter': query_filter,
+                        'limit': PAGINATION_LIMIT,
+                        'skip': len(users)
+                    }
+                )
+                users.extend([user.to_dict() for user in api_response.results])
+                if len(users) == api_response.total_count:
+                    return users
         except ApiException as error:
-            raise JcApiException("Exception when calling SystemusersApi:\n") from error
-
-    def get_users(self, limit='100', skip=0, search='', filter='', sort='', fields=''):
-        """
-        Get users from jumpcloud
-        :param limit:
-        :param skip:
-        :param search:
-        :param filter:
-        :param sort:
-        :param fields:
-        :return: a list of users with dict of settings
-        """
-        try:
-            api_response = self.system_users_api.systemusers_list(content_type='application/json',
-                                                                  accept='application/json',
-                                                                  limit=limit,
-                                                                  skip=skip,
-                                                                  sort=sort,
-                                                                  fields=fields,
-                                                                  x_org_id='',
-                                                                  search=search,
-                                                                  filter=filter)
-            users = [user.to_dict() for user in class_to_dict(api_response.results)]
-            return users
-        except ApiException as error:
-            raise JcApiException("Exception when calling SystemusersApi:\n") from error
+            raise JcApiException("Exception when calling SearchApi:\n") from error
 
     def create_user(self, systemuser):
         """
@@ -143,7 +123,7 @@ class JumpcloudApiV1:
         :param username
         :return:  the user id
         """
-        users = self.get_users(limit='', fields="username")
+        users = self.search_users()
 
         for user in users:
             if user['username'] == username:

--- a/jccli/jc_api_v2.py
+++ b/jccli/jc_api_v2.py
@@ -159,12 +159,12 @@ class JumpcloudApiV2:
         :param group_name: name of the JC group
         :return:  The jumpcloud group id and type, NONE group is not found
         """
-        groups = self.get_groups(limit=limit, skip=skip, sort=sort, fields=fields)
+        groups = self.get_groups()
         for group in groups:
             if group['name'] == group_name and group['type'] == group_type:
                 return group
 
-    def get_groups(self, type=None, limit=100, skip=0, sort='', fields='') -> List[Group]:
+    def get_groups(self, type=None) -> List[Group]:
         # pylint: disable-msg=too-many-locals
         # pylint: disable-msg=too-many-arguments
         """

--- a/jccli/jc_api_v2.py
+++ b/jccli/jc_api_v2.py
@@ -199,14 +199,17 @@ class JumpcloudApiV2:
     def list_group_users(self, group_id):
         """Return a list of user IDs associated with the group ID
         """
-        results: List[GraphConnection] = self.user_groups_api.graph_user_group_members_list(
-            group_id=group_id,
-            content_type='application/json',
-            accept='application/json'
-        )
         user_ids = []
-        for result in results:
-            user = result.to_dict()['to']
-            user_ids.append(user['id'])
+        while True:
+            results: List[GraphConnection] = self.user_groups_api.graph_user_group_members_list(
+                group_id=group_id,
+                content_type='application/json',
+                accept='application/json',
+                limit=PAGE_LIMIT,
+                skip=len(user_ids)
+            )
+            if len(results) == 0:
+                break
+            user_ids.extend([result.to_dict()['to']['id'] for result in results])
 
         return user_ids

--- a/unit_tests/test_cli.py
+++ b/unit_tests/test_cli.py
@@ -12,7 +12,7 @@ module.
 import json
 import pytest
 from jcapiv1 import Systemuserslist, Systemuser, System, Systemslist
-from jcapiv2 import Group
+from jcapiv2 import Group, GraphConnection, GraphObject
 import jccli.cli as cli
 
 # fmt: on
@@ -25,8 +25,10 @@ from jccli.jc_api_v2 import JumpcloudApiV2
 
 
 MOCK_USER_GROUPS = [Group(id=str(i), name='group-%d' % (i,), type='user_group') for i in range(2*PAGE_LIMIT+2)]
-MOCK_USERS_LIST = [Systemuser(username='user-%d' % (i,), email='fakeemail%d@fakesite.org' % (i,)) for i in range(1, 2 * PAGE_LIMIT + 2)]
+MOCK_USERS_LIST = [Systemuser(id='%d' % (i,), username='user-%d' % (i,), email='fakeemail%d@fakesite.org' % (i,)) for i in range(1, 2 * PAGE_LIMIT + 2)]
 MOCK_SYSTEMS_LIST = [System(id=str(i)) for i in range(2 * PAGE_LIMIT + 1)]
+MOCK_GROUP_ID = '6789defg'
+MOCK_GROUP_MEMBER_USER_IDS = [user.id for user in MOCK_USERS_LIST]
 
 
 def mock_search_users(self, content_type, accept, body, **kwargs):
@@ -49,6 +51,14 @@ def mock_groups_list(self, content_type, accept, limit, skip, filter, **kwargs):
     """Mock of groups_api.groups_list(), used for testing pagination
     """
     return MOCK_USER_GROUPS[skip:skip+limit]
+
+
+def mock_list_user_group_members(self, content_type, accept, group_id, limit, skip, **kwargs):
+    """Mock of user_groups_api.graph_user_group_members_list(), used for testing pagination.
+    (Pretends that all users are members of this group)
+    """
+    assert group_id == MOCK_GROUP_ID
+    return [GraphConnection(to=GraphObject(id=user.id, type='user')) for user in MOCK_USERS_LIST[skip:skip+limit]]
 
 
 class TestCli:
@@ -291,3 +301,28 @@ class TestCli:
             raise result.exception
         observed_response = json.loads(result.output)
         assert observed_response == [system.to_dict() for system in MOCK_SYSTEMS_LIST]
+
+    @unittest_patch('jcapiv1.api.search_api.SearchApi.search_systemusers_post', new=mock_search_users)
+    @unittest_patch('jcapiv2.api.user_groups_api.UserGroupsApi.graph_user_group_members_list', new=mock_list_user_group_members)
+    @patch('jccli.jc_api_v2.JumpcloudApiV2.get_group')
+    def test_group_users_pagination(self, mock_get_group):
+        """Test that list-systems can handle pagination
+        """
+        mock_get_group.return_value = {'id': MOCK_GROUP_ID}
+        runner: CliRunner = CliRunner()
+        result: Result = runner.invoke(
+            cli.cli,
+            [
+                '--key',
+                '1234-abcd',
+                'group',
+                'list-users',
+                '--name',
+                'fake-group'
+            ]
+        )
+
+        if result.exit_code:
+            raise result.exception
+        observed_response = json.loads(result.output)
+        assert observed_response == [user.to_dict() for user in MOCK_USERS_LIST]

--- a/unit_tests/test_jc_api_v1.py
+++ b/unit_tests/test_jc_api_v1.py
@@ -26,9 +26,9 @@ class TestJcApiV1:
     def teardown_method(self, test_method):
         pass
 
-    @patch.object(JumpcloudApiV1, 'get_users')
-    def test_get_user_id(self, mock_get_users):
-        mock_get_users.return_value = [
+    @patch.object(JumpcloudApiV1, 'search_users')
+    def test_get_user_id(self, mock_search_users):
+        mock_search_users.return_value = [
             {
                 'account_locked': False,
                 'activated': False,
@@ -82,8 +82,8 @@ class TestJcApiV1:
              user_id == "5dc0d38c1e2e5f51f2312948"
         ), "Failed to get the user ID"
 
-    @patch.object(JumpcloudApiV1,'get_users')
-    def test_get_user_id_not_found(self, mock_get_users):
+    @patch.object(JumpcloudApiV1, 'search_users')
+    def test_get_user_id_not_found(self, mock_search_users):
         response = [
             {
                 'email': 'jc.tester1@sagebase.org',
@@ -93,7 +93,7 @@ class TestJcApiV1:
             }
         ]
         api1 = JumpcloudApiV1("1234")
-        mock_get_users.return_value = response
+        mock_search_users.return_value = response
         with pytest.raises(SystemUserNotFoundError):
             api1.get_user_id("foo")
 
@@ -148,7 +148,7 @@ class TestJcApiV1:
         assert (user_search == [])
 
         call_args, call_kwargs = mock_search_systemusers_post.call_args
-        assert (call_kwargs['body'] == {'filter': {'and': [{'firstname': 'David'}]}})
+        assert (call_kwargs['body']['filter'] == {'and': [{'firstname': 'David'}]})
 
     @patch.object(jcapiv1.SearchApi, 'search_systemusers_post')
     def test_search_users_no_field(self, mock_search_systemusers_post):
@@ -169,7 +169,7 @@ class TestJcApiV1:
 
         call_args, call_kwargs = mock_search_systemusers_post.call_args
         assert (
-                call_kwargs['body'] == {'filter': None}
+                call_kwargs['body']['filter'] == None
         )
 
     @patch.object(jcapiv1.SearchApi, 'search_systemusers_post')
@@ -191,7 +191,7 @@ class TestJcApiV1:
 
         call_args, call_kwargs = mock_search_systemusers_post.call_args
         assert (
-            call_kwargs['body'] == {'filter': {'and': [{'firstname': 'David'}]}}
+            call_kwargs['body']['filter'] == {'and': [{'firstname': 'David'}]}
         )
 
     @patch.object(jcapiv1.SearchApi, 'search_systemusers_post')
@@ -214,7 +214,7 @@ class TestJcApiV1:
 
         call_args, call_kwargs = mock_search_systemusers_post.call_args
         assert (
-                call_kwargs['body'] == {'filter': {'and': [{'firstname': 'David'}, {'lastname': 'Smith'}]}}
+                call_kwargs['body']['filter'] == {'and': [{'firstname': 'David'}, {'lastname': 'Smith'}]}
         )
 
     @patch.object(jcapiv1.SystemusersApi, 'systemusers_put')
@@ -235,13 +235,13 @@ class TestJcApiV1:
             api_response == user.to_dict()
         ), "set_user did not correctly call the systemusers_put API method"
 
-    @patch.object(JumpcloudApiV1, 'get_users')
-    def test_set_user_no_id(self, mock_systemusers_list):
-        mock_systemusers_list.return_value = [
+    @patch.object(JumpcloudApiV1, 'search_users')
+    def test_set_user_no_id(self, mock_systemusers_search):
+        mock_systemusers_search.return_value = [
             {
-                'firstname':'Mary',
-                'username':'mary',
-                'email':'mary@google.microsoft'
+                'firstname': 'Mary',
+                'username': 'mary',
+                'email': 'mary@google.microsoft'
             }
         ]
         api1 = JumpcloudApiV1("1234")


### PR DESCRIPTION
Make all list API calls handle pagination. Also adds tests for that functionality, with a mocked API.

We should still have somebody run the `list` commands on a JumpCloud instance that actually has more than 100 of some unit (systems, groups, users, or ideally all of them) just to double check that it actually fetches all of them.