### PR TITLE
[Fixes #85] Build & Publish JC Agent Docker Image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,71 @@
+name: build  #based on template https://github.com/docker/build-push-action
+
+on:
+  push:
+    tags:
+      - 'jcagentv(\d+)(\d+)(\d+)'  # build on tags like "jcagentvXX.YY.ZZ"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout src
+        uses: actions/checkout@v2
+      -
+        name: Read repo metadata
+        id: repo
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const repo = await github.repos.get(context.repo)
+            return repo.data
+      -
+        name: Versioning logic
+        id: prep
+        run: |
+          DOCKER_PATH=jcagent #Name of repo on Dockerhub is "jcagent"
+          VERSION=$( echo ${GITHUB_REF} |sed -e "s#refs/tags/jcagent##g" ) #Remove "jcagent" from front of tag to get version number
+          TAGS="${DOCKER_PATH},\
+                ${DOCKER_PATH}:${VERSION},"
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=container_user::${{ github.repository_owner }}
+          echo ::set-output name=source_repo::${DOCKER_PATH} #Pull layers from DockerHub
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push image
+        id: docker_build_and_push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: integration_tests/jc-agent/Dockerfile
+          platforms: linux/amd64 #, linux/arm64, linux/386
+          build-args: |
+            version=${{ steps.prep.outputs.version }}
+            container_user=${{ steps.prep.outputs.container_user }}
+            source_repo=${{ steps.prep.outputs.source_repo }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=${{ fromJson(steps.repo.outputs.result).name }}
+            org.opencontainers.image.description="${{ fromJson(steps.repo.outputs.result).description }}"
+            org.opencontainers.image.url=${{ fromJson(steps.repo.outputs.result).html_url }}
+            org.opencontainers.image.source=${{ fromJson(steps.repo.outputs.result).clone_url }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ fromJson(steps.repo.outputs.result).license.spdx_id }}

--- a/integration_tests/jc-agent/Dockerfile
+++ b/integration_tests/jc-agent/Dockerfile
@@ -1,0 +1,30 @@
+# Must be run in interactive mode to activate;
+# Recommended run method:
+# docker run -dit --env JC_CONNECT_KEY=<your-connect-key-here> <container-reference-here>
+FROM ubuntu:20.04
+
+LABEL maintainer="github.com/cascadianblue"
+
+ARG version
+RUN test -n "${version}"
+
+ENV version=${version}
+LABEL version=${version}
+LABEL about.license="SPDX:Apache-2.0"
+
+# Install dependencies
+RUN apt-get update -qq -y && apt-get install --no-install-recommends -qq -y \
+        apt-transport-https \
+        curl \
+        ca-certificates \
+    && update-ca-certificates \
+    && apt-get -y autoclean \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
+# Kludgily install apt-show-versions
+RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes \
+    && apt-get -o Acquire::GzipIndexes=false update \
+    && apt-get install -y apt-show-versions
+
+CMD curl --tlsv1.2 --silent --show-error --header "x-connect-key: ${JC_CONNECT_KEY}" https://kickstart.jumpcloud.com/Kickstart | bash; bash


### PR DESCRIPTION
Builds and deploys the Docker image with JC Agent installed (for the purpose of testing `system` command group) to Dockerhub whenever the repo is tagged with a tag of format `jcagentvXX.YY.ZZ` (open to suggestions on a different tag format)